### PR TITLE
fix: use NPM OIDC trusted publisher instead of token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,6 +125,9 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Upgrade npm to OIDC-compatible version
+        run: npm install -g npm@latest
+
       - name: Verify version matches release tag
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
@@ -135,10 +138,8 @@ jobs:
           fi
           echo "✅ Version match: $PACKAGE_VERSION"
 
-      - name: Publish to NPM with provenance
+      - name: Publish to NPM with provenance (OIDC trust)
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # ─────────────────────────────────────────────────────────────
   # PUBLISH TO GITHUB PACKAGES — mirrors the NPM publish


### PR DESCRIPTION
## Summary

The publish workflow was failing with NODE_AUTH_TOKEN empty because the token-based publish is deprecated in favor of NPM OIDC trusted publishers.

### Changes
- Remove NODE_AUTH_TOKEN env var (conflicts with OIDC)
- Upgrade npm to latest (>=11.5.1) for OIDC publishing support
- Keep id-token: write permission and --provenance flag

NPM trusted publisher is already configured on npmjs.com for this repo. OIDC federates identity from GitHub Actions → NPM, eliminating the need for long-lived tokens.

## Test plan
- [ ] Merge this PR
- [ ] Re-run failed publish workflow or re-create v1.7.1 release
- [ ] Verify publish to NPM succeeds with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)