### PR TITLE
fix: Node 24 + OIDC publish + skip guard (v1.7.2)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Setup Node.js for GitHub Packages
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://npm.pkg.github.com"
 
       - name: Verify version matches release tag
@@ -170,7 +170,21 @@ jobs:
           fi
           echo "✅ Version match: $PACKAGE_VERSION"
 
+      - name: Check if version already published to GitHub Packages
+        id: gh_pkg_check
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          if npm view "@techwavedev/agi-agent-kit@${PACKAGE_VERSION}" version --registry=https://npm.pkg.github.com 2>/dev/null; then
+            echo "already_published=true" >> $GITHUB_OUTPUT
+            echo "⚠️  Version ${PACKAGE_VERSION} already published to GitHub Packages. Skipping."
+          else
+            echo "already_published=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish to GitHub Packages
+        if: steps.gh_pkg_check.outputs.already_published != 'true'
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-04-04
+
+### Fixed
+
+- **NPM publish workflow** — Migrated from token-based auth to OIDC trusted publisher. Upgraded to Node 24 (ships with npm 11.x needed for OIDC). Added skip-if-already-published guard for GitHub Packages to allow re-running failed workflows.
+
 ## [1.7.1] - 2026-04-04
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techwavedev/agi-agent-kit",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Enterprise-Grade Agentic Framework - Modular skill-based AI assistant toolkit with deterministic execution, semantic memory, and platform-adaptive orchestration.",
   "bin": {
     "agi-agent-kit": "./bin/init.js"


### PR DESCRIPTION
Fixes the NPM publish workflow:

- Upgrade to Node 24 (ships with npm 11.x needed for OIDC trusted publishing). Node 22 breaks when npm is upgraded manually (MODULE_NOT_FOUND on promise-retry).
- Add skip guard for publish-github job to detect already-published versions and avoid 409 conflicts on re-runs.
- Bump to 1.7.2 because 1.7.1 is already on GitHub Packages from a previous partial failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)