### PR TITLE
fix: publish job Node 24 for OIDC (v1.7.3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,11 +122,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Upgrade npm to OIDC-compatible version
-        run: npm install -g npm@latest
+      - name: Verify npm version (OIDC requires >=11.5.1)
+        run: |
+          node --version
+          npm --version
 
       - name: Verify version matches release tag
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techwavedev/agi-agent-kit",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Enterprise-Grade Agentic Framework - Modular skill-based AI assistant toolkit with deterministic execution, semantic memory, and platform-adaptive orchestration.",
   "bin": {
     "agi-agent-kit": "./bin/init.js"


### PR DESCRIPTION
PR #19 only fixed publish-github. The publish job still used Node 22 + npm upgrade step which breaks. This applies the same fix to the publish job. Bumps to 1.7.3.