### PR TITLE
fix(security): harden verify_webhook() to fully close py/reflective-xss

### DIFF
--- a/templates/skills/extended/other/whatsapp-cloud-api/assets/boilerplate/nodejs/src/webhook-handler.ts
+++ b/templates/skills/extended/other/whatsapp-cloud-api/assets/boilerplate/nodejs/src/webhook-handler.ts
@@ -67,13 +67,22 @@ export function handleWebhookVerification(verifyToken: string) {
     const challenge = req.query['hub.challenge'] as string;
 
     if (mode === 'subscribe' && token === verifyToken) {
+      // Strictly validate the challenge shape before echoing it. Meta sends
+      // an opaque token of alphanumerics, dashes and underscores — anything
+      // else is a tampered request and must not be echoed, preventing any
+      // reflected XSS via the challenge parameter.
+      if (typeof challenge !== 'string' || !/^[A-Za-z0-9_\-]{1,256}$/.test(challenge)) {
+        console.warn('Webhook verification failed: invalid challenge shape');
+        res.sendStatus(400);
+        return;
+      }
       console.log('Webhook verified successfully');
-      // Force plain text so the echoed challenge cannot be interpreted as
-      // HTML/JavaScript by a browser (prevents reflected XSS on the echo).
+      // Force plain text as a defence in depth so the validated challenge
+      // still cannot be interpreted as HTML/JavaScript by a browser.
       res
         .status(200)
         .type('text/plain')
-        .send(String(challenge ?? ''));
+        .send(challenge);
     } else {
       console.warn('Webhook verification failed: invalid token');
       res.sendStatus(403);

--- a/templates/skills/extended/other/whatsapp-cloud-api/assets/boilerplate/python/webhook_handler.py
+++ b/templates/skills/extended/other/whatsapp-cloud-api/assets/boilerplate/python/webhook_handler.py
@@ -3,10 +3,11 @@
 import hashlib
 import hmac
 import os
+import re
 from functools import wraps
 from typing import Any
 
-from flask import Request, abort, request
+from flask import Response, abort, request
 
 
 def validate_hmac_signature(app_secret: str | None = None):
@@ -44,16 +45,25 @@ def validate_hmac_signature(app_secret: str | None = None):
 def verify_webhook(verify_token: str | None = None):
     """
     Handle webhook verification (GET request from Meta).
-    Returns the challenge to confirm the webhook endpoint.
+
+    Echoes the challenge back as ``text/plain`` so the reflected value cannot
+    be interpreted as HTML/JavaScript by a browser (prevents reflected XSS).
+    Meta only inspects the body contents, so the content-type override is
+    protocol-safe.
     """
     token = verify_token or os.environ["VERIFY_TOKEN"]
 
     mode = request.args.get("hub.mode")
     req_token = request.args.get("hub.verify_token")
-    challenge = request.args.get("hub.challenge")
+    challenge = request.args.get("hub.challenge", "")
 
     if mode == "subscribe" and req_token == token:
-        return challenge, 200
+        # Strictly validate the challenge shape: Meta sends an opaque token
+        # made of alphanumerics, dashes and underscores. Anything else is a
+        # tampered request — reject it rather than echoing.
+        if not re.fullmatch(r"[A-Za-z0-9_\-]{1,256}", challenge):
+            abort(400, "Invalid challenge")
+        return Response(challenge, status=200, mimetype="text/plain")
     else:
         abort(403, "Verification failed")
 


### PR DESCRIPTION
## Summary

Follow-up to #20. After that PR merged, CodeQL re-scanned and still flagged `py/reflective-xss` in the WhatsApp Cloud API boilerplate because my fix in #20 wrapped `verify_webhook()` from the caller side instead of fixing the function itself. CodeQL correctly saw that `verify_webhook()` still returned the raw user-supplied challenge as a Flask response body with the default `text/html` content-type.

This PR fixes it at the source:

- `verify_webhook()` now strictly validates the challenge shape (`^[A-Za-z0-9_\-]{1,256}$`). Any tampered request is rejected with **400** *before* any echo.
- Returns an explicit `flask.Response` with `mimetype="text/plain"` so even a valid challenge cannot be interpreted as HTML/JavaScript.
- `app.py`'s `webhook_verify()` is a trivial passthrough again — the security now lives in the one function that actually produces the response.

This closes the last real code-level CodeQL finding from the original 23.

## Why the previous fix wasn't enough

In #20 I did:
```python
challenge = verify_webhook()
return (str(challenge), 200, {"Content-Type": "text/plain; charset=utf-8"})
```
But `verify_webhook()` already returned a `(body, status)` tuple, so `str(challenge)` stringified the tuple (a latent bug), and more importantly CodeQL's taint tracker followed the user input all the way through `verify_webhook()` to the Flask response body before the caller could override anything.

Fixing at the source removes the taint sink entirely.

## Test plan

- [ ] CodeQL re-runs on this PR — the remaining `py/reflective-xss` alert should flip to `fixed`.
- [ ] Manual: hit `GET /webhook?hub.mode=subscribe&hub.verify_token=<valid>&hub.challenge=abc123` and confirm `Content-Type: text/plain` and body `abc123`.
- [ ] Manual: hit with `hub.challenge=<script>alert(1)</script>` and confirm 400 Bad Request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)